### PR TITLE
Specify the Vault Project ID via CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ terraform.tfvars
 
 # TLS keys
 tls/*
+# Keep the .keep file so the directory is available during cert creation
+!tls/.keep
 
 # Vault tokens
 token.json

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,7 +108,6 @@ spec:
      stage('Teardown') {
       container(containerName) {
         sh "make teardown"
-        sh "gcloud auth revoke"
       }
      }
    }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,8 +25,7 @@ limitations under the License.
 def label = "k8s-infra"
 def containerName = "k8s-node"
 def GOOGLE_APPLICATION_CREDENTIALS    = '/home/jenkins/dev/jenkins-deploy-dev-infra.json'
-// Tells the ./scripts/common.sh to install the vault CLI binary of VAULT_VERSION
-def IS_CI_ENV = 'true'
+// Tells the ./scripts/common.sh which VAULT_VERSION of the vault CLI binary to use
 def VAULT_VERSION = '1.0.2'
 
 podTemplate(label: label, yaml: """
@@ -58,8 +57,6 @@ spec:
     properties([disableConcurrentBuilds()])
     // set env variable GOOGLE_APPLICATION_CREDENTIALS for Terraform
     env.GOOGLE_APPLICATION_CREDENTIALS=GOOGLE_APPLICATION_CREDENTIALS
-    // set env variable for the validate script to know it's in a CI environment
-    env.IS_CI_ENV=IS_CI_ENV
 
     stage('Setup') {
         container(containerName) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,11 +44,18 @@ spec:
     # Mount the dev service account key
     - name: dev-key
       mountPath: /home/jenkins/dev
+    # Mount the host /dev/urandom to /dev/random for entropy
+    - name: random
+      mountPath: /dev/random
   volumes:
   # Create a volume that contains the dev json key that was saved as a secret
   - name: dev-key
     secret:
       secretName: jenkins-deploy-dev-infra
+  # Host /dev/urandom to allow for entropy access
+  - name: random
+    hostPath:
+      path: /dev/urandom
 """
  ) {
  node(label) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,7 +106,6 @@ spec:
    finally {
      stage('Teardown') {
       container(containerName) {
-        sh "sleep 600"
         sh "make teardown"
         sh "gcloud auth revoke"
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,6 +106,7 @@ spec:
    finally {
      stage('Teardown') {
       container(containerName) {
+        sh "sleep 600"
         sh "make teardown"
         sh "gcloud auth revoke"
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,6 +35,7 @@ metadata:
   labels:
     jenkins: build-node
 spec:
+  automountServiceAccountToken: false
   containers:
   - name: ${containerName}
     image: gcr.io/pso-helmsman-cicd/jenkins-k8s-node:${env.CONTAINER_VERSION}

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,9 @@
+approvers:
+  - chrislovecnm
+  - robinpercy
+  - geojaz
+  - techgnosis
+  - erkolson
+  - bgeesaman
+labels:
+  - gke-helmsman

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -57,6 +57,8 @@ command -v vault >/dev/null 2>&1 || { \
 
 # Set false if the ENV var isn't already set/present
 IS_CI_ENV=${IS_CI_ENV:-false}
+# Set empty if the ENV var isn't already set/present
+VAULT_PROJECT_ID=${VAULT_PROJECT_ID:-}
 # Release ID of the desired version of vault
 VAULT_VERSION=${VAULT_VERSION:-"1.0.2"}
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -105,17 +105,28 @@ if [[ -z "${REGION}" ]]; then
     exit 1;
 fi
 
-BILLING_ACCOUNT="$(gcloud beta billing accounts list --format='value(name.basename())')"
-if [[ -z "${BILLING_ACCOUNT}" ]]; then
-    echo "Your gcloud project must have a billing account set up."
-    echo "Visit https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_an_existing_project."
-    exit 1;
-fi
+# The vault-on-gke module requires these to be set to be able to create
+# new GCP projects, but we are also passing an existing project ID from
+# our env VAULT_PROJECT_ID variable which bypasses the project creation
+# step.  When in 
+BILLING_ACCOUNT=""
+ORG_ID=""
+# If this is not running in CI, obtain the needed env VARS for vault-on-gke
+if [[ "${IS_CI_ENV}" != "true" ]]; then
 
-ORG_ID="$(gcloud organizations list --format='value(name.basename())')"
-if [[ -z "${ORG_ID}" ]]; then
-    echo "There was an error obtaining the organization ID for the current configuration."
-    exit 1;
+  # Ensures the two env VARS needed by vault-on-gke to create projects are set
+  BILLING_ACCOUNT="$(gcloud beta billing accounts list --format='value(name.basename())')"
+  if [[ -z "${BILLING_ACCOUNT}" ]]; then
+      echo "Your gcloud project must have a billing account set up."
+      echo "Visit https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_an_existing_project."
+      exit 1;
+  fi
+  
+  ORG_ID="$(gcloud organizations list --format='value(name.basename())')"
+  if [[ -z "${ORG_ID}" ]]; then
+      echo "There was an error obtaining the organization ID for the current configuration."
+      exit 1;
+  fi
 fi
 
 # Exports vault-specific items to the current shell's ENV to aid in vault cli usage.

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -74,9 +74,9 @@ if [[ "${IS_CI_ENV}" == "true" ]]; then
     mv "${ROOT}/vault" "${ROOT}/bin/vault"
     chmod +x "${ROOT}/bin/vault"
 
-    # Add the local bin directory to the CI $PATH
-    export PATH="${ROOT}/bin:$PATH"
   fi
+  # Add the local bin directory to the CI $PATH
+  export PATH="${ROOT}/bin:$PATH"
 fi
 
 # Make sure vault is installed.  If not, refer to:

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -108,7 +108,7 @@ fi
 # The vault-on-gke module requires these to be set to be able to create
 # new GCP projects, but we are also passing an existing project ID from
 # our env VAULT_PROJECT_ID variable which bypasses the project creation
-# step.  When in 
+# step.
 BILLING_ACCOUNT=""
 ORG_ID=""
 # If this is not running in CI, obtain the needed env VARS for vault-on-gke
@@ -121,7 +121,7 @@ if [[ "${IS_CI_ENV}" != "true" ]]; then
       echo "Visit https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_an_existing_project."
       exit 1;
   fi
-  
+
   ORG_ID="$(gcloud organizations list --format='value(name.basename())')"
   if [[ -z "${ORG_ID}" ]]; then
       echo "There was an error obtaining the organization ID for the current configuration."

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -47,14 +47,6 @@ command -v kubectl >/dev/null 2>&1 || { \
  exit 1
 }
 
-# Make sure vault is installed.  If not, refer to:
-# https://learn.hashicorp.com/vault/getting-started/install
-command -v vault >/dev/null 2>&1 || { \
- echo >&2 "I require vault but it's not installed.  Aborting."
- echo >&2 "Refer to: https://learn.hashicorp.com/vault/getting-started/install"
- exit 1
-}
-
 # Set false if the ENV var isn't already set/present
 IS_CI_ENV=${IS_CI_ENV:-false}
 # Set empty if the ENV var isn't already set/present
@@ -86,6 +78,14 @@ if [[ "${IS_CI_ENV}" == "true" ]]; then
     export PATH="${ROOT}/bin:$PATH"
   fi
 fi
+
+# Make sure vault is installed.  If not, refer to:
+# https://learn.hashicorp.com/vault/getting-started/install
+command -v vault >/dev/null 2>&1 || { \
+ echo >&2 "I require vault but it's not installed.  Aborting."
+ echo >&2 "Refer to: https://learn.hashicorp.com/vault/getting-started/install"
+ exit 1
+}
 
 # Set specific ENV variables used by the Google Gloud SDK
 PROJECT="$(gcloud config get-value core/project)"

--- a/scripts/generate-tfvars.sh
+++ b/scripts/generate-tfvars.sh
@@ -52,4 +52,10 @@ kubernetes_master_authorized_networks = [
   },
 ]
 EOF
+    if [[ ! -z "${VAULT_PROJECT_ID}" ]]
+    then
+    cat <<EOF >> "${TFVARS_FILE}"
+vault_project="${VAULT_PROJECT_ID}"
+EOF
+    fi
 fi

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -16,9 +16,9 @@ limitations under the License.
 
 # Add user-specified roles
 resource "google_project_iam_member" "service-account" {
-  count   = "${length(var.service_account_roles)}"
-  project = "${var.project}"
-  role    = "${element(var.service_account_roles, count.index)}"
-  member  = "serviceAccount:vault-server@${module.vault.project}.iam.gserviceaccount.com"
+  count      = "${length(var.service_account_roles)}"
+  project    = "${var.project}"
+  role       = "${element(var.service_account_roles, count.index)}"
+  member     = "serviceAccount:vault-server@${module.vault.project}.iam.gserviceaccount.com"
   depends_on = ["module.vault"]
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -18,7 +18,7 @@ limitations under the License.
 // https://www.terraform.io/docs/providers/google/d/google_container_engine_versions.html
 data "google_container_engine_versions" "gke_version" {
   project = "${var.project}"
-  region = "${var.region}"
+  region  = "${var.region}"
 }
 
 # Create the dedicated GKE service account for the application cluster
@@ -127,12 +127,12 @@ resource "google_container_cluster" "app" {
     services_secondary_range_name = "${google_compute_subnetwork.app-subnetwork.secondary_ip_range.1.range_name}"
   }
 
-   # Specify the list of CIDRs which can access the GKE API Server
+  # Specify the list of CIDRs which can access the GKE API Server
   master_authorized_networks_config {
     cidr_blocks = ["${var.kubernetes_master_authorized_networks}"]
   }
 
-   # Configure the cluster to be private (not have public facing IPs)
+  # Configure the cluster to be private (not have public facing IPs)
   private_cluster_config {
     # This field is misleading. This prevents access to the master API from
     # any external IP. While that might represent the most secure
@@ -141,7 +141,7 @@ resource "google_container_cluster" "app" {
     # can talk to that endpoint.
     enable_private_endpoint = false
 
-     enable_private_nodes   = true
+    enable_private_nodes   = true
     master_ipv4_cidr_block = "${var.kubernetes_masters_ipv4_cidr}"
   }
 

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -21,23 +21,23 @@ resource "google_compute_address" "app-nat" {
   project = "${var.project}"
   region  = "${var.region}"
 
-   depends_on = [
+  depends_on = [
     "google_project_service.app_service",
   ]
 }
 
- # Create a network for GKE
+# Create a network for GKE
 resource "google_compute_network" "app-network" {
   name                    = "app-network"
   project                 = "${var.project}"
   auto_create_subnetworks = false
 
-   depends_on = [
+  depends_on = [
     "google_project_service.app_service",
   ]
 }
 
- # Create subnets
+# Create subnets
 resource "google_compute_subnetwork" "app-subnetwork" {
   name          = "app-subnetwork"
   project       = "${var.project}"
@@ -45,47 +45,47 @@ resource "google_compute_subnetwork" "app-subnetwork" {
   region        = "${var.region}"
   ip_cidr_range = "${var.kubernetes_network_ipv4_cidr}"
 
-   private_ip_google_access = true
+  private_ip_google_access = true
 
-   secondary_ip_range {
+  secondary_ip_range {
     range_name    = "app-pods"
     ip_cidr_range = "${var.kubernetes_pods_ipv4_cidr}"
   }
 
-   secondary_ip_range {
+  secondary_ip_range {
     range_name    = "app-svcs"
     ip_cidr_range = "${var.kubernetes_services_ipv4_cidr}"
   }
 }
 
- # Create a NAT router so the nodes can reach DockerHub, etc
+# Create a NAT router so the nodes can reach DockerHub, etc
 resource "google_compute_router" "app-router" {
   name    = "app-router"
   project = "${var.project}"
   region  = "${var.region}"
   network = "${google_compute_network.app-network.self_link}"
 
-   bgp {
+  bgp {
     asn = 64514
   }
 }
 
- resource "google_compute_router_nat" "app-nat" {
+resource "google_compute_router_nat" "app-nat" {
   name    = "app-nat-1"
   project = "${var.project}"
   router  = "${google_compute_router.app-router.name}"
   region  = "${var.region}"
 
-   nat_ip_allocate_option = "MANUAL_ONLY"
+  nat_ip_allocate_option = "MANUAL_ONLY"
   nat_ips                = ["${google_compute_address.app-nat.*.self_link}"]
 
-   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
 
-   subnetwork {
+  subnetwork {
     name                    = "${google_compute_subnetwork.app-subnetwork.self_link}"
     source_ip_ranges_to_nat = ["PRIMARY_IP_RANGE", "LIST_OF_SECONDARY_IP_RANGES"]
 
-     secondary_ip_range_names = [
+    secondary_ip_range_names = [
       "${google_compute_subnetwork.app-subnetwork.secondary_ip_range.0.range_name}",
       "${google_compute_subnetwork.app-subnetwork.secondary_ip_range.1.range_name}",
     ]

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -15,21 +15,21 @@ limitations under the License.
 */
 
 output "vault-address" {
-    value = "${module.vault.address}"
+  value = "${module.vault.address}"
 }
 
 output "vault-root-token" {
-    value = "${module.vault.root_token}"
+  value = "${module.vault.root_token}"
 }
 
 output "vault-project" {
-    value = "${module.vault.project}"
+  value = "${module.vault.project}"
 }
 
 output "vault-region" {
-    value = "${module.vault.region}"
+  value = "${module.vault.region}"
 }
 
 output "application-cluster-name" {
-    value = "${var.application_cluster_name}"
+  value = "${var.application_cluster_name}"
 }

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
 // Configles the Google Cloud Provider with default settings
 provider "google" {
   project = "${var.project}"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -17,28 +17,28 @@ limitations under the License.
 // Required variables
 variable "project" {
   description = "The name of the project in which to create the Kubernetes clusters."
-  type = "string"
+  type        = "string"
 }
 
 variable "billing_account" {
   description = "The billing_account ID to attach to the project for attributing costs."
-  type = "string"
+  type        = "string"
 }
 
 variable "org_id" {
   description = "The organization to hold the newly created project."
-  type = "string"
+  type        = "string"
 }
 
 // Optional variables
 variable "region" {
   description = "The region in which the GKE clusters will run."
-  default = "us-west1"
+  default     = "us-west1"
 }
 
 variable "gke_master_version" {
   description = "The minimum version to use for the GKE control plane."
-  default = "latest"
+  default     = "latest"
 }
 
 variable "application_cluster_name" {
@@ -64,6 +64,7 @@ variable "app_project_services" {
     "logging.googleapis.com",
     "monitoring.googleapis.com",
   ]
+
   description = "The APIs that will be enabled in the application cluster project."
 }
 
@@ -78,8 +79,8 @@ EOF
 }
 
 variable "daily_maintenance_window" {
-  type    = "string"
-  default = "06:00"
+  type        = "string"
+  default     = "06:00"
   description = "The 4 hr block each day when we want GKE to perform maintenance if needed."
 }
 
@@ -160,6 +161,7 @@ variable "service_account_roles" {
     "roles/iam.serviceAccountAdmin",
     "roles/resourcemanager.projectIamAdmin",
   ]
+
   description = <<EOF
 List of roles to be granted to the vault-server SA in this application cluster
 project for managing SAs and SA Keys.

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Required variables
 variable "project" {
-  description = "The name of the project in which to create the Kubernetes clusters."
+  description = "The name of the project in which to create the Application Kubernetes cluster."
   type        = "string"
 }
 
@@ -28,6 +28,17 @@ variable "billing_account" {
 variable "org_id" {
   description = "The organization to hold the newly created project."
   type        = "string"
+}
+
+// If specified, this project ID is passed to the vault-on-gke module
+// to use an existing project name for the vault cluster.  If omitted,
+// the vault-on-gke module generates one for you in the format of
+// vault-XXXXXXX by default.
+variable "vault_project" {
+  description = "The name of the project in which to create the Vault Demo App Kubernetes cluster."
+  type        = "string"
+
+  default = ""
 }
 
 // Optional variables

--- a/terraform/vault.tf
+++ b/terraform/vault.tf
@@ -19,4 +19,5 @@ module "vault" {
   org_id                                = "${var.org_id}"
   billing_account                       = "${var.billing_account}"
   kubernetes_master_authorized_networks = "${var.kubernetes_master_authorized_networks}"
+  project                               = "${var.vault_project}"
 }

--- a/terraform/vault.tf
+++ b/terraform/vault.tf
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 module "vault" {
-  source = "github.com/sethvargo/vault-on-gke//terraform"
-  org_id = "${var.org_id}"
-  billing_account = "${var.billing_account}"
+  source                                = "github.com/sethvargo/vault-on-gke//terraform"
+  org_id                                = "${var.org_id}"
+  billing_account                       = "${var.billing_account}"
   kubernetes_master_authorized_networks = "${var.kubernetes_master_authorized_networks}"
 }


### PR DESCRIPTION
Terraform formatting and allowing for CI to pass a `VAULT_PROJECT_ID` to the `vault-on-gke` module to specify the existing (but separate) project to hold the Vault cluster.