### PR TITLE
Move back to the jenkins namespace

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ def GOOGLE_APPLICATION_CREDENTIALS    = '/home/jenkins/dev/jenkins-deploy-dev-in
 // Tells the ./scripts/common.sh which VAULT_VERSION of the vault CLI binary to use
 def VAULT_VERSION = '1.0.2'
 
-podTemplate(namespace: "default", label: label, yaml: """
+podTemplate(label: label, yaml: """
 apiVersion: v1
 kind: Pod
 metadata:

--- a/scripts/auth-to-vault.sh
+++ b/scripts/auth-to-vault.sh
@@ -51,10 +51,10 @@ vault audit enable file file_path=stdout
 gcloud container clusters get-credentials --region "${REGION}" "${GKE_NAME}"
 
 # Create the vault-auth service account
-kubectl create serviceaccount vault-auth
+kubectl create serviceaccount vault-auth -n default
 
 # Create the RBAC rolebinding for token review for the vault-auth service account
-kubectl apply -f - <<EOH
+kubectl apply -n default -f - <<EOH
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -74,11 +74,11 @@ EOH
 DIR="$(pwd)/tls"
 
 # Get the name of the secret corresponding to the service account
-SECRET_NAME="$(kubectl get serviceaccount vault-auth \
+SECRET_NAME="$(kubectl get serviceaccount vault-auth -n default \
   -o go-template='{{ (index .secrets 0).name }}')"
 
 # Get the actual token reviewer account
-TR_ACCOUNT_TOKEN="$(kubectl get secret "${SECRET_NAME}" \
+TR_ACCOUNT_TOKEN="$(kubectl get secret "${SECRET_NAME}" -n default \
   -o go-template='{{ .data.token }}' | base64 --decode)"
 
 # Get the host for the cluster (IP address)
@@ -115,9 +115,9 @@ vault write auth/kubernetes/role/myapp-role \
 
 # Enable our workloads to find vault
 # Create a config map to store the vault address
-kubectl create configmap vault \
+kubectl create configmap vault -n default \
   --from-literal "vault_addr=${VAULT_ADDR}"
 
 # Create a secret for our CA
-kubectl create secret generic vault-tls \
+kubectl create secret generic vault-tls -n default \
   --from-file "${DIR}/ca.pem"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -60,12 +60,12 @@ vault kv put secret/myapp/config \
   apikey='MYAPIKEYHERE'
 
 # install the auto-init sidecar
-kubectl apply -f "${ROOT}/k8s-manifests/sidecar.yaml" #2> /dev/null 1> /dev/null
+kubectl apply -n default -f "${ROOT}/k8s-manifests/sidecar.yaml" #2> /dev/null 1> /dev/null
 
 # Loop for up to 180 seconds waiting for vault to be ready
 SECRETSREADY=""
 for _ in {1..90}; do
-  SECRETSREADY=$(kubectl exec -it "$(kubectl get pod -l "app=kv-sidecar" -o jsonpath="{.items[0].metadata.name}")" -c app -- cat /etc/secrets/config | grep "apikey")
+  SECRETSREADY=$(kubectl exec -it -n default "$(kubectl get pod -n default -l "app=kv-sidecar" -o jsonpath="{.items[0].metadata.name}")" -c app -- cat /etc/secrets/config | grep "apikey")
   [ ! -z "$SECRETSREADY" ] && break
   sleep 2
 done


### PR DESCRIPTION
With https://github.com/sethvargo/vault-on-gke/pull/53 merged, we should be able to move back to the `jenkins` namespace for running the build jobs.